### PR TITLE
Completing documentation to build samr21_xpro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # Zephyr-101
-workbook to record my progres on DevAcademy Nordic semiconductor
+workbook to record my progres with ZephyRTOS
+
+# Working with application
+First we need on Zephyr a structure folder to work in a proper  way. 
+
+A Zephyr application directory has the following components: 
+
+- CMakeLists.txt: your build settings configuration file – this tells west (really a cmake build system under the hood) where to find what it needs to create your firmware. For more advanced projects, it’s also used for debug settings, emulation, and other features.
+- prj.conf: the Kernel configuration file. For most projects, it tells Zephyr whether to include specific features for use in your application code – if you use GPIO, PWM, or a serial monitor, you’ll need to enable them in this file first. 
+- src/main.c: your custom application code – where the magic happens! It’s advisable to put all of your custom source code in a 
+src/ directory like this so it doesn’t get mixed up with your configuration files.
+
+- Optional boards/ or soc/ overlay directories: in some cases, the board or even the specific MCU chip you want to use might not be supported yet in Zephyr. If this is the case, you can create your own definitions in your custom projects. It’s out of the scope of this starting tutorial, but it’s a good option to know about. 
+
+# how to build and run Zephyr OS
+go to your zeohyr_base folder and run the following command: 
+```bash 
+cd ~/zephyrproject
+west --version
+mkdir applications
+cd applications
+cp ~/zephyrproject/zephyr/samples/basic/blinky/{CMakeLists, src/main.c, prj.conf} .
+cd ~/zephyrproject/applications/
+west build -p auto -b samr21_xpro -s .
+```
+

--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,8 @@ This application can be built and executed on QEMU as follows:
 
 To build for another board, change "qemu_x86" above to that board's name.
 
+
+Build Locally
+*************
+
+


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `README.rst` files to provide clearer instructions and additional details for working with Zephyr RTOS.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R27): Updated the project description and added detailed instructions on the structure of a Zephyr application directory, including explanations for `CMakeLists.txt`, `prj.conf`, `src/main.c`, and optional overlay directories. Also included a step-by-step guide on how to build and run Zephyr OS.
* [`README.rst`](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR26-R30): Added a new section titled "Build Locally" to provide instructions for building the application locally.